### PR TITLE
Avoid precip wrap at greenwich meridian when doing linear interpolation

### DIFF
--- a/bin/backup-bp-variables-to-jasmin-gws
+++ b/bin/backup-bp-variables-to-jasmin-gws
@@ -9,7 +9,10 @@ src_root="/user/work/vf20964/moose/${domain}/"
 destination="xfer1.jasmin:/gws/nopw/j04/bris_climdyn/henrya/bp-backups/moose/${domain}/"
 
 set -x
-rsync -avhz --include '2.2km-coarsened-4x-2.2km-coarsened-4x/***' --include '2.2km-coarsened-gcm-2.2km-coarsened-4x/***' --include '60km-2.2km-coarsened-4x/***' --exclude '*/' ${src_root} ${destination}
+rsync -avhz --delete --include '2.2km-coarsened-4x-2.2km-coarsened-4x/***' --include '2.2km-coarsened-gcm-2.2km-coarsened-4x/***' --include '60km-2.2km-coarsened-4x/***' --exclude '*/' ${src_root} ${destination}
+
+rsync -avhz --include='/archive/*/' ${src_root} ${destination}
+
 set +x
 
 # backup datasets too

--- a/bin/get-data-sample
+++ b/bin/get-data-sample
@@ -6,7 +6,9 @@ variable=$1
 domain=$2
 target_sf=$3
 variable_sf=$4
-unscaled_variable_resolution=${5:-"2.2km"}
+ensemble_member=${5:-"01"}
+unscaled_variable_resolution=${6:-"2.2km"}
+
 
 if [[ ${unscaled_variable_resolution} == "2.2km" ]]; then
   collection="land-cpm"

--- a/bin/get-nc-dataset
+++ b/bin/get-nc-dataset
@@ -6,7 +6,7 @@ set -euo pipefail
 dataset=$1
 bp_host=${2:-"bp"}
 
-ds_path="nc-datasets/${dataset}/"
+ds_path="nc-datasets/${dataset}"
 
 bp_path="/user/work/vf20964/moose/${ds_path}"
 local_path="${MOOSE_DERIVED_DATA}/${ds_path}"
@@ -17,7 +17,7 @@ set -x
 
 bp_tmpdir="/user/work/vf20964/tmp"
 
-ssh ${bp_host} "lsub -a geog022743 -m 64 -q short,compute,cnu --condaenv downscaling-data -- mlde-data sample --output-dir ${bp_tmpdir} ${bp_path}/*.nc"
-rsync -avz ${bp_host}:${bp_tmpdir}/${bp_path} ${local_path}
-rsync -avz ${bp_host}:${bp_path}/ds-config.yml ${local_path}
+ssh ${bp_host} "./mambaforge/envs/downscaling-data/bin/mlde-data sample --output-dir ${bp_tmpdir} ${bp_path}/*.nc"
+rsync -avhz ${bp_host}:${bp_tmpdir}/${bp_path}/ ${local_path}
+rsync -avhz ${bp_host}:${bp_path}/ds-config.yml ${local_path}
 ssh ${bp_host} "rm ${bp_tmpdir}/${bp_path}/*.nc"

--- a/moose-etl/cpm/pr/extract-day-linpr
+++ b/moose-etl/cpm/pr/extract-day-linpr
@@ -24,11 +24,7 @@ echo
 # no job initially to wait on
 job_id=0
 
-years=$(seq 1981 1 1990)
-job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
-echo $job_id
-
-years=$(seq 1991 1 2000)
+years=$(seq 1981 1 2000)
 job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
 echo $job_id
 
@@ -36,11 +32,7 @@ echo $job_id
 # no job initially to wait on
 job_id=0
 
-years=$(seq 2021 1 2030)
-job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
-echo $job_id
-
-years=$(seq 2031 1 2040)
+years=$(seq 2021 1 2040)
 job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
 echo $job_id
 
@@ -48,10 +40,6 @@ echo $job_id
 # no job initially to wait on
 job_id=0
 
-years=$(seq 2061 1 2070)
-job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
-echo $job_id
-
-years=$(seq 2071 1 2080)
+years=$(seq 2061 1 2080)
 job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
 echo $job_id

--- a/moose-etl/gcm/pr/extract-day-linpr
+++ b/moose-etl/gcm/pr/extract-day-linpr
@@ -24,11 +24,7 @@ echo
 # no job initially to wait on
 job_id=0
 
-years=$(seq 1981 1 1990)
-job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
-echo $job_id
-
-years=$(seq 1991 1 2000)
+years=$(seq 1981 1 2000)
 job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
 echo $job_id
 
@@ -36,11 +32,7 @@ echo $job_id
 # no job initially to wait on
 job_id=0
 
-years=$(seq 2021 1 2030)
-job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
-echo $job_id
-
-years=$(seq 2031 1 2040)
+years=$(seq 2021 1 2040)
 job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
 echo $job_id
 
@@ -48,10 +40,6 @@ echo $job_id
 # no job initially to wait on
 job_id=0
 
-years=$(seq 2061 1 2070)
-job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
-echo $job_id
-
-years=$(seq 2071 1 2080)
+years=$(seq 2061 1 2080)
 job_id=$(${QUEUE_DEP_PATH} -j ${job_id} -d ${SCRIPT_DIR} -- ${BATCH_WRAPPER_PATH} -d ${domain} -s ${scale_factor} -t ${target_resolution} -p ${target_size} -v ${variable} -f ${frequency} -e ${ensemble_member} ${years})
 echo $job_id

--- a/src/mlde_data/bin/variable.py
+++ b/src/mlde_data/bin/variable.py
@@ -26,6 +26,7 @@ from ..preprocessing.diff import Diff
 from ..preprocessing.regrid import Regrid
 from ..preprocessing.remapcon import Remapcon
 from ..preprocessing.select_domain import SelectDomain
+from ..preprocessing.shift_lon_break import ShiftLonBreak
 from ..preprocessing.sum import Sum
 from ..preprocessing.vorticity import Vorticity
 
@@ -240,6 +241,8 @@ def create(
                         f"{variable_resolution}-coarsened-{scale_factor}x"
                     )
                     ds, orig_ds = Coarsen(scale_factor=scale_factor).run(ds)
+        elif job_spec["action"] == "shift_lon_break":
+            ds = ShiftLonBreak().run(ds)
         elif job_spec["action"] == "regrid_to_target":
             if target_resolution != variable_resolution:
                 typer.echo(f"Regridding to target resolution...")

--- a/src/mlde_data/config/variables/day/land-cpm/linpr.yml
+++ b/src/mlde_data/config/variables/day/land-cpm/linpr.yml
@@ -22,6 +22,7 @@ spec:
     params:
       variables: [lssnow, lsrain]
       new_variable: linpr
+  - action: shift_lon_break
   - action: regrid_to_target
     variable: linpr
     parameters:

--- a/src/mlde_data/config/variables/day/land-gcm/linpr.yml
+++ b/src/mlde_data/config/variables/day/land-gcm/linpr.yml
@@ -14,6 +14,7 @@ sources:
 spec:
   - action: rename
     mapping: {"pr": "linpr"}
+  - action: shift_lon_break
   - action: regrid_to_target
     variable: linpr
     parameters:

--- a/src/mlde_data/preprocessing/regrid.py
+++ b/src/mlde_data/preprocessing/regrid.py
@@ -21,8 +21,6 @@ class Regrid:
         self.variables = variables
         self.scheme = self.SCHEMES[scheme]()
 
-        pass
-
     def run(self, ds):
         # regrid the coarsened data to match the original horizontal grid (using NN interpolation)
         # NB iris and xarray can only comminicate in dataarrays not datasets
@@ -62,7 +60,7 @@ class Regrid:
 
         for variable in self.variables:
             src_cube = ds[variable].to_iris()
-            # conversion to iris looses the coordinate system on the lat and long dimensions but iris it needs to do regrid
+            # conversion to iris loses the coordinate system on the lat and long dimensions but iris it needs to do regrid
             src_cube.coords(src_lon_name)[0].coord_system = src_coord_sys
             src_cube.coords(src_lat_name)[0].coord_system = src_coord_sys
 

--- a/src/mlde_data/preprocessing/shift_lon_break.py
+++ b/src/mlde_data/preprocessing/shift_lon_break.py
@@ -1,0 +1,17 @@
+"""
+Change longitude from 0-360 to -180 to 180
+so break doesn't appear over UK
+"""
+
+
+class ShiftLonBreak:
+    def __init__(self, lon_name="longitude") -> None:
+        self.lon_name = lon_name
+
+    def run(self, ds):
+        orig_lon_attrs = ds[self.lon_name].attrs
+        ds.coords[self.lon_name] = (ds.coords[self.lon_name] + 180) % 360 - 180
+        ds = ds.sortby(ds[self.lon_name])
+        ds[self.lon_name].attrs = orig_lon_attrs
+
+        return ds

--- a/tests/preprocessing/test_shift_lon_break.py
+++ b/tests/preprocessing/test_shift_lon_break.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from mlde_data.preprocessing.shift_lon_break import ShiftLonBreak
+
+
+def test_shift_lon_break(global_dataset):
+    orig_lon_attrs = global_dataset["longitude"].attrs
+
+    ds = ShiftLonBreak().run(global_dataset)
+
+    assert ds["longitude"].min().values.item() == -180.0
+    assert ds["longitude"].max().values.item() == 170.0
+    assert ds["longitude"].attrs == orig_lon_attrs
+
+
+@pytest.fixture
+def global_dataset():
+    lon_attrs = {"axis": "X", "units": "degrees_east", "standard_name": "longitude"}
+    longitude = xr.Variable(["longitude"], np.linspace(0, 350, 36), attrs=lon_attrs)
+
+    latitude = xr.Variable(["latitude"], np.linspace(-90, 90, 19), attrs={})
+
+    ds = xr.Dataset(
+        {"foo": (("longitude", "latitude"), np.random.rand(36, 19))},
+        coords={"longitude": longitude, "latitude": latitude},
+    )
+
+    return ds


### PR DESCRIPTION
Shift break in longitude 180 degrees before doing linear interplolation of coarse precip so don't end up with weird (including negative values) through the middle of the bham domain.

Also switch linpr extract scripts to have one job per time period so it's simpler to re-start after failure. And fix a few issues with helper scripts for getting samples of variables and datasets to play with locally.