### PR TITLE
Allow multiple target variables in datasets

### DIFF
--- a/bin/migrate-configs.py
+++ b/bin/migrate-configs.py
@@ -1,0 +1,35 @@
+# TO DO (after GH merge): python migrate-configs $DERIVED_DATA/moose/nc-datasets/*/ds-config.yml
+# DONE: python migrate-configs src/mlde_data/configs/datasets/*.yml
+
+import sys
+import yaml
+
+for fpath in sys.argv[1:]:
+    print(fpath, flush=True)
+    with open(fpath, "r") as f:
+        config = yaml.safe_load(f)
+
+    orig_predictand = config.pop("predictand")
+
+    new_predictands = {
+        "variables": [orig_predictand["variable"]],
+        "resolution": orig_predictand["resolution"],
+    }
+
+    config["predictands"] = new_predictands
+
+    orig_predictors = config.pop("predictors")
+    orig_resolution = config.pop("resolution")
+
+    new_predictors = {
+        "variables": [v["variable"] for v in orig_predictors],
+        "resolution": orig_resolution,
+    }
+
+    config["predictors"] = new_predictors
+
+    if "split" in config:
+        config["split"] = config.pop("split")
+
+    with open(fpath, "w") as f:
+        yaml.dump(config, f, default_flow_style=False)

--- a/src/mlde_data/config/datasets/bham-256_gcmx-1x_vorticity850_random.yml
+++ b/src/mlde_data/config/datasets/bham-256_gcmx-1x_vorticity850_random.yml
@@ -1,11 +1,13 @@
 domain: birmingham-256
+ensemble_member: '01'
 frequency: day
-ensemble_member: "01"
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-2.2km
+  variables:
+  - pr
 predictors:
-  - variable: vorticity850
+  resolution: 2.2km-coarsened-gcm-2.2km
+  variables:
+  - vorticity850
+scenario: rcp85
 split_scheme: random

--- a/src/mlde_data/config/datasets/bham_60km-4x_12em_linpr_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_60km-4x_12em_linpr_eqvt_random-season.yml
@@ -1,15 +1,29 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
+- '04'
+- '05'
+- '06'
+- '07'
+- 08
+- 09
+- '10'
+- '11'
+- '12'
+- '13'
+- '15'
 frequency: day
-ensemble_members: ["01", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "15"]
-scenario: rcp85
-resolution: 60km-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: linpr
+  resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - linpr
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_60km-4x_12em_psl-sphum4th-temp4th-vort4th_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_60km-4x_12em_psl-sphum4th-temp4th-vort4th_eqvt_random-season.yml
@@ -1,27 +1,41 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
+- '04'
+- '05'
+- '06'
+- '07'
+- 08
+- 09
+- '10'
+- '11'
+- '12'
+- '13'
+- '15'
 frequency: day
-ensemble_members: ["01", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "15"]
-scenario: rcp85
-resolution: 60km-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: psl
-  - variable: spechum250
-  - variable: spechum500
-  - variable: spechum700
-  - variable: spechum850
-  - variable: temp250
-  - variable: temp500
-  - variable: temp700
-  - variable: temp850
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
+  resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - psl
+  - spechum250
+  - spechum500
+  - spechum700
+  - spechum850
+  - temp250
+  - temp500
+  - temp700
+  - temp850
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_60km-4x_12em_psl-temp4th-vort4th_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_60km-4x_12em_psl-temp4th-vort4th_eqvt_random-season.yml
@@ -1,23 +1,37 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
+- '04'
+- '05'
+- '06'
+- '07'
+- 08
+- 09
+- '10'
+- '11'
+- '12'
+- '13'
+- '15'
 frequency: day
-ensemble_members: ["01", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "15"]
-scenario: rcp85
-resolution: 60km-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: psl
-  - variable: temp250
-  - variable: temp500
-  - variable: temp700
-  - variable: temp850
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
+  resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - psl
+  - temp250
+  - temp500
+  - temp700
+  - temp850
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_60km-4x_1em_linpr_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_60km-4x_1em_linpr_eqvt_random-season.yml
@@ -1,15 +1,18 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 60km-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: linpr
+  resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - linpr
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_60km-4x_1em_psl-sphum4th-temp4th-vort4th_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_60km-4x_1em_psl-sphum4th-temp4th-vort4th_eqvt_random-season.yml
@@ -1,27 +1,30 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 60km-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: psl
-  - variable: spechum250
-  - variable: spechum500
-  - variable: spechum700
-  - variable: spechum850
-  - variable: temp250
-  - variable: temp500
-  - variable: temp700
-  - variable: temp850
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
+  resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - psl
+  - spechum250
+  - spechum500
+  - spechum700
+  - spechum850
+  - temp250
+  - temp500
+  - temp700
+  - temp850
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_60km-4x_1em_psl-temp-vort_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_60km-4x_1em_psl-temp-vort_eqvt_random-season.yml
@@ -1,25 +1,28 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 60km-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: psl
-  - variable: temp250
-  - variable: temp500
-  - variable: temp700
-  - variable: temp850
-  - variable: temp925
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
-  - variable: vorticity925
+  resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - psl
+  - temp250
+  - temp500
+  - temp700
+  - temp850
+  - temp925
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+  - vorticity925
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_60km-4x_1em_psl-temp4th-vort4th_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_60km-4x_1em_psl-temp4th-vort4th_eqvt_random-season.yml
@@ -1,23 +1,26 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 60km-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: psl
-  - variable: temp250
-  - variable: temp500
-  - variable: temp700
-  - variable: temp850
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
+  resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - psl
+  - temp250
+  - temp500
+  - temp700
+  - temp850
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_60km-4x_1em_vort850_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_60km-4x_1em_vort850_eqvt_random-season.yml
@@ -1,15 +1,18 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 60km-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: vorticity850
+  resolution: 60km-2.2km-coarsened-4x
+  variables:
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_60km-60km_12em_rawpr_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_60km-60km_12em_rawpr_eqvt_random-season.yml
@@ -1,15 +1,29 @@
 domain: birmingham-9
+ensemble_members:
+- '01'
+- '04'
+- '05'
+- '06'
+- '07'
+- 08
+- 09
+- '10'
+- '11'
+- '12'
+- '13'
+- '15'
 frequency: day
-ensemble_members: ["01", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "15"]
-scenario: rcp85
-resolution: 60km-60km
-predictand:
-  variable: pr
+predictands:
   resolution: 60km-60km
+  variables:
+  - pr
 predictors:
-  - variable: pr
+  resolution: 60km-60km
+  variables:
+  - pr
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_60km-60km_1em_rawpr_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_60km-60km_1em_rawpr_eqvt_random-season.yml
@@ -1,15 +1,18 @@
 domain: birmingham-9
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 60km-60km
-predictand:
-  variable: pr
+predictands:
   resolution: 60km-60km
+  variables:
+  - pr
 predictors:
-  - variable: pr
+  resolution: 60km-60km
+  variables:
+  - pr
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_12em_linpr_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_12em_linpr_eqvt_random-season.yml
@@ -1,15 +1,29 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
+- '04'
+- '05'
+- '06'
+- '07'
+- 08
+- 09
+- '10'
+- '11'
+- '12'
+- '13'
+- '15'
 frequency: day
-ensemble_members: ["01", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "15"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: linpr
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - linpr
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_12em_psl-sphum4th-temp4th-vort4th_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_12em_psl-sphum4th-temp4th-vort4th_eqvt_random-season.yml
@@ -1,27 +1,41 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
+- '04'
+- '05'
+- '06'
+- '07'
+- 08
+- 09
+- '10'
+- '11'
+- '12'
+- '13'
+- '15'
 frequency: day
-ensemble_members: ["01", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "15"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: psl
-  - variable: spechum250
-  - variable: spechum500
-  - variable: spechum700
-  - variable: spechum850
-  - variable: temp250
-  - variable: temp500
-  - variable: temp700
-  - variable: temp850
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - psl
+  - spechum250
+  - spechum500
+  - spechum700
+  - spechum850
+  - temp250
+  - temp500
+  - temp700
+  - temp850
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_12em_psl-temp4th-vort4th_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_12em_psl-temp4th-vort4th_eqvt_random-season.yml
@@ -1,23 +1,37 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
+- '04'
+- '05'
+- '06'
+- '07'
+- 08
+- 09
+- '10'
+- '11'
+- '12'
+- '13'
+- '15'
 frequency: day
-ensemble_members: ["01", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "15"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: psl
-  - variable: temp250
-  - variable: temp500
-  - variable: temp700
-  - variable: temp850
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - psl
+  - temp250
+  - temp500
+  - temp700
+  - temp850
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_12em_vort4th_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_12em_vort4th_eqvt_random-season.yml
@@ -1,18 +1,32 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
+- '04'
+- '05'
+- '06'
+- '07'
+- 08
+- 09
+- '10'
+- '11'
+- '12'
+- '13'
+- '15'
 frequency: day
-ensemble_members: ["01", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "15"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_12em_vort850_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_12em_vort850_eqvt_random-season.yml
@@ -1,15 +1,29 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
+- '04'
+- '05'
+- '06'
+- '07'
+- 08
+- 09
+- '10'
+- '11'
+- '12'
+- '13'
+- '15'
 frequency: day
-ensemble_members: ["01", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "15"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: vorticity850
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_1em_linpr_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_1em_linpr_eqvt_random-season.yml
@@ -1,15 +1,18 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: linpr
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - linpr
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_1em_mv.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_1em_mv.yml
@@ -1,0 +1,31 @@
+domain: birmingham-64
+ensemble_members:
+- '01'
+frequency: day
+predictands:
+  resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
+  - tmean150cm
+predictors:
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - psl
+  - spechum250
+  - spechum500
+  - spechum700
+  - spechum850
+  - temp250
+  - temp500
+  - temp700
+  - temp850
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+scenario: rcp85
+split:
+  scheme: random-season
+  seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_1em_psl-sphum4th-temp4th-vort4th_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_1em_psl-sphum4th-temp4th-vort4th_eqvt_random-season.yml
@@ -1,27 +1,30 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: psl
-  - variable: spechum250
-  - variable: spechum500
-  - variable: spechum700
-  - variable: spechum850
-  - variable: temp250
-  - variable: temp500
-  - variable: temp700
-  - variable: temp850
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - psl
+  - spechum250
+  - spechum500
+  - spechum700
+  - spechum850
+  - temp250
+  - temp500
+  - temp700
+  - temp850
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_1em_psl-temp-vort_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_1em_psl-temp-vort_eqvt_random-season.yml
@@ -1,25 +1,28 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: psl
-  - variable: temp250
-  - variable: temp500
-  - variable: temp700
-  - variable: temp850
-  - variable: temp925
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
-  - variable: vorticity925
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - psl
+  - temp250
+  - temp500
+  - temp700
+  - temp850
+  - temp925
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+  - vorticity925
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_1em_psl-temp4th-vort4th_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_1em_psl-temp4th-vort4th_eqvt_random-season.yml
@@ -1,23 +1,26 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: psl
-  - variable: temp250
-  - variable: temp500
-  - variable: temp700
-  - variable: temp850
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - psl
+  - temp250
+  - temp500
+  - temp700
+  - temp850
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_1em_vort4th_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_1em_vort4th_eqvt_random-season.yml
@@ -1,18 +1,21 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: vorticity250
-  - variable: vorticity500
-  - variable: vorticity700
-  - variable: vorticity850
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - vorticity250
+  - vorticity500
+  - vorticity700
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-4x_1em_vort850_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-4x_1em_vort850_eqvt_random-season.yml
@@ -1,15 +1,18 @@
 domain: birmingham-64
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-4x-2.2km-coarsened-4x
+  variables:
+  - pr
 predictors:
-  - variable: vorticity850
+  resolution: 2.2km-coarsened-gcm-2.2km-coarsened-4x
+  variables:
+  - vorticity850
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-60km_12em_pr_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-60km_12em_pr_eqvt_random-season.yml
@@ -1,15 +1,29 @@
 domain: birmingham-9
+ensemble_members:
+- '01'
+- '04'
+- '05'
+- '06'
+- '07'
+- 08
+- 09
+- '10'
+- '11'
+- '12'
+- '13'
+- '15'
 frequency: day
-ensemble_members: ["01", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "15"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-60km
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-gcm-60km
+  variables:
+  - pr
 predictors:
-  - variable: pr
+  resolution: 2.2km-coarsened-gcm-60km
+  variables:
+  - pr
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/config/datasets/bham_gcmx-60km_1em_pr_eqvt_random-season.yml
+++ b/src/mlde_data/config/datasets/bham_gcmx-60km_1em_pr_eqvt_random-season.yml
@@ -1,15 +1,18 @@
 domain: birmingham-9
+ensemble_members:
+- '01'
 frequency: day
-ensemble_members: ["01"]
-scenario: rcp85
-resolution: 2.2km-coarsened-gcm-60km
-predictand:
-  variable: pr
+predictands:
   resolution: 2.2km-coarsened-gcm-60km
+  variables:
+  - pr
 predictors:
-  - variable: pr
+  resolution: 2.2km-coarsened-gcm-60km
+  variables:
+  - pr
+scenario: rcp85
 split:
   scheme: random-season
-  val_prop: 0.15
-  test_prop: 0.15
   seed: 42
+  test_prop: 0.15
+  val_prop: 0.15

--- a/src/mlde_data/dataset/__init__.py
+++ b/src/mlde_data/dataset/__init__.py
@@ -51,64 +51,40 @@ def _combine_variables(em: str, config: dict, input_base_dir: Path):
     """
     Combine predictor and predictand variables for a given ensemble into a single dataset
     """
-    predictand_var_params = {k: config[k] for k in ["domain", "scenario", "frequency"]}
-    predictand_var_params.update(
-        {
-            "variable": config["predictand"]["variable"],
-            "resolution": config["predictand"]["resolution"],
-        }
-    )
-    predictand_meta = VariableMetadata(
-        input_base_dir / "moose", ensemble_member=em, **predictand_var_params
-    )
 
-    predictors_meta = []
-    for predictor_var_config in config["predictors"]:
-        var_params = {
-            k: config[k]
-            for k in [
-                "domain",
-                "scenario",
-                "frequency",
-                "resolution",
-            ]
-        }
-        var_params.update({k: predictor_var_config[k] for k in ["variable"]})
-        predictors_meta.append(
-            VariableMetadata(input_base_dir / "moose", ensemble_member=em, **var_params)
-        )
+    common_var_params = {k: config[k] for k in ["domain", "scenario", "frequency"]}
 
-    predictor_datasets = []
-    for dsmeta in predictors_meta:
-        predictor_ds = xr.open_mfdataset(
-            dsmeta.existing_filepaths(),
-            data_vars="minimal",
-            combine="by_coords",
-            compat="no_conflicts",
-            combine_attrs="drop_conflicts",
-        )
-        predictor_ds[dsmeta.variable] = predictor_ds[dsmeta.variable].expand_dims(
-            dict(ensemble_member=[em])
-        )
+    variable_datasets = []
+    for var_type in ["predictors", "predictands"]:
+        var_type_config = config[var_type]
+        for predictor_var_name in var_type_config["variables"]:
+            dsmeta = VariableMetadata(
+                input_base_dir / "moose",
+                ensemble_member=em,
+                variable=predictor_var_name,
+                resolution=var_type_config["resolution"],
+                **common_var_params,
+            )
 
-        predictor_datasets.append(predictor_ds)
+            variable_ds = xr.open_mfdataset(
+                dsmeta.existing_filepaths(),
+                data_vars="minimal",
+                combine="by_coords",
+                compat="no_conflicts",
+                combine_attrs="drop_conflicts",
+            )
+            variable_ds[dsmeta.variable] = variable_ds[dsmeta.variable].expand_dims(
+                dict(ensemble_member=[em])
+            )
+            if var_type == "predictands":
+                variable_ds = variable_ds.rename(
+                    {dsmeta.variable: f"target_{dsmeta.variable}"}
+                )
 
-    predictand_ds = xr.open_mfdataset(
-        predictand_meta.existing_filepaths(),
-        data_vars="minimal",
-        combine="by_coords",
-        compat="no_conflicts",
-        combine_attrs="drop_conflicts",
-    )
-    predictand_ds[predictand_meta.variable] = predictand_ds[
-        predictand_meta.variable
-    ].expand_dims(dict(ensemble_member=[em]))
-    predictand_ds = predictand_ds.rename(
-        {predictand_meta.variable: f"target_{predictand_meta.variable}"}
-    )
+            variable_datasets.append(variable_ds)
 
     single_em_ds = xr.combine_by_coords(
-        [*predictor_datasets, predictand_ds],
+        variable_datasets,
         compat="no_conflicts",
         combine_attrs="drop_conflicts",
         join="exact",

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,0 +1,101 @@
+import cftime
+from mlde_utils import VariableMetadata
+import numpy as np
+import os
+import pytest
+import xarray as xr
+
+from mlde_data import dataset
+
+
+@pytest.fixture
+def config():
+    return {
+        "domain": "test-10",
+        "frequency": "day",
+        "ensemble_members": ["01"],
+        "scenario": "rcp85",
+        "predictands": {
+            "resolution": "2.2km",
+            "variables": ["output1", "output2"],
+        },
+        "predictors": {
+            "resolution": "60km",
+            "variables": ["input1", "input2"],
+        },
+        "split": {
+            "scheme": "random-season",
+            "test_prop": 0.2,
+            "val_prop": 0.2,
+            "seed": 42,
+        },
+    }
+
+
+@pytest.fixture
+def variable_files(tmp_path, config):
+    years = [1981]
+    for em in config["ensemble_members"]:
+        for var_type in ["predictands", "predictors"]:
+            for var in config[var_type]["variables"]:
+                print(var)
+                meta = VariableMetadata(
+                    tmp_path / "moose",
+                    ensemble_member=em,
+                    domain=config["domain"],
+                    variable=var,
+                    resolution=config[var_type]["resolution"],
+                    scenario=config["scenario"],
+                    frequency=config["frequency"],
+                )
+                os.makedirs(meta.dirpath(), exist_ok=False)
+                for year in years:
+                    print(meta.filepath(year))
+                    variable_ds_factory(var, year).to_netcdf(meta.filepath(year))
+
+    return tmp_path
+
+
+def variable_ds_factory(var, year):
+    time_range = xr.cftime_range(
+        cftime.Datetime360Day(year - 1, 12, 1, 12, 0, 0, 0, has_year_zero=True),
+        periods=360,
+        freq="D",
+    )
+    grid_lat_range = np.linspace(-2, 2, 10)
+    grid_lon_range = np.linspace(-2, 2, 10)
+
+    ds = xr.Dataset(
+        data_vars={
+            var: (
+                ["time", "grid_longitude", "grid_latitude"],
+                np.random.randn(
+                    len(time_range), len(grid_lat_range), len(grid_lon_range)
+                ),
+            ),
+        },
+        coords=dict(
+            time=(["time"], time_range),
+            grid_longitude=(["grid_longitude"], grid_lon_range),
+            grid_latitude=(["grid_latitude"], grid_lat_range),
+        ),
+    )
+
+    return ds
+
+
+def test_combine_variables(variable_files, config):
+    input_base_dir = variable_files
+
+    result = dataset._combine_variables("01", config, input_base_dir)
+
+    assert result.dims == {
+        "ensemble_member": 1,
+        "time": 360,
+        "grid_longitude": 10,
+        "grid_latitude": 10,
+    }
+    assert result["input1"].shape == (1, 360, 10, 10)
+    assert result["input2"].shape == (1, 360, 10, 10)
+    assert result["target_output1"].shape == (1, 360, 10, 10)
+    assert result["target_output2"].shape == (1, 360, 10, 10)


### PR DESCRIPTION
Change how datasets are configured and created to include multiple target predictand variables

This will require some migration of the config file in the datasets on disk once merged. The actual netCDF files themselves will be fine, just the ds-config.yml file that sits with them. Fortunately there's a helper script for that