### PR TITLE
Create multiple variables from same xarray Dataset loaded from pp data

### DIFF
--- a/bin/moose/cpm/extract-missing-predictors
+++ b/bin/moose/cpm/extract-missing-predictors
@@ -1,0 +1,21 @@
+#! /bin/bash
+# Accidentally deleted most predictor variables for default ensemble member, so re-extracting them here.
+# Will run variable creation separately to avoid overloading the mass machine
+
+set -euo pipefail
+
+em="r001i1p00000"
+
+set -x
+
+for year in $(seq 1981 1990); do
+  echo ${year};
+  for var in mlqtw psl; do
+    pixi run --as-is --locked mlde-data moose extract --collection land-cpm --scenario rcp85 --variable ${var} --year ${year} --frequency day --ensemble-member ${em}; echo "DONE for ${var} ${year}";
+  done
+  echo "DONE for ${year}";
+done
+
+set +x
+
+echo "DONE"

--- a/config/datasets/engwales_ccpm-4x_12em_1981-1990_1hr_pr.yml
+++ b/config/datasets/engwales_ccpm-4x_12em_1981-1990_1hr_pr.yml
@@ -1,0 +1,52 @@
+scenario: rcp85
+domain: engwales
+ensemble_members:
+  - r001i1p00000
+  - r001i1p01113
+  - r001i1p01554
+  - r001i1p01649
+  - r001i1p01843
+  - r001i1p01935
+  - r001i1p02868
+  - r001i1p02123
+  - r001i1p02242
+  - r001i1p02305
+  - r001i1p02335
+  - r001i1p02491
+predictands:
+  frequency: 1hr
+  resolution: 2.2km-coarsened-4x
+  collection: land-cpm
+  variables:
+    - pr
+predictors:
+  frequency: day
+  resolution: 2.2km-coarsened-gcm
+  collection: land-cpm
+  variables:
+      # - pr
+      - psl
+      - spechum250
+      - spechum500
+      - spechum700
+      - spechum850
+      - temp250
+      - temp500
+      - temp700
+      - temp850
+      - vorticity250
+      - vorticity500
+      - vorticity700
+      - vorticity850
+split:
+  scheme: random-season
+  time_periods:
+    - ["1980-12-01", "1990-11-30"]
+    # - ["1980-12-01", "2000-12-01"]
+    # - ["2040-12-01", "2040-12-01"]
+    # - ["2060-12-01", "2080-12-01"]
+  seed: 42
+  props:
+    train: 0.6
+    val: 0.2
+    test: 0.2

--- a/config/variables/day/land-cpm/predictors/vorticity.yml
+++ b/config/variables/day/land-cpm/predictors/vorticity.yml
@@ -10,6 +10,11 @@ sources:
     # assumes already extracted and converted to nc
     - name: mlqtw
 spec:
+  - action: drop-variables
+    parameters:
+      variables:
+        - air_temperature
+        - specific_humidity
   - action: query
     parameters:
       query:
@@ -26,8 +31,6 @@ spec:
       variables:
         - x_wind
         - y_wind
-        - air_temperature
-        - specific_humidity
   - action: select-subdomain
     parameters:
       domain: ${domain}

--- a/src/mlde_data/bin/etl.py
+++ b/src/mlde_data/bin/etl.py
@@ -2,7 +2,7 @@ import logging
 import os
 from pathlib import Path
 from mlde_utils import RAW_MOOSE_VARIABLES_PATH
-from mlde_data.options import DomainOption
+from mlde_data.options import DomainOption, CollectionOption
 from mlde_data.bin.moose import extract, clean
 from mlde_data.bin.variable import create as create_variable
 from mlde_data.variable import load_config
@@ -77,7 +77,7 @@ def moose(
                 variable=src_config.variable,
                 year=year,
                 frequency=src_config.frequency,
-                collection=src_config.collection,
+                collection=CollectionOption(src_config.collection),
                 ensemble_member=ensemble_member,
                 scenario=scenario,
             )
@@ -98,7 +98,7 @@ def moose(
         if cleanup:
             for src_config in src_configs:
                 clean(
-                    collection=src_config.collection,
+                    collection=CollectionOption(src_config.collection),
                     scenario=scenario,
                     ensemble_member=ensemble_member,
                     variable=src_config.variable,

--- a/src/mlde_data/bin/etl.py
+++ b/src/mlde_data/bin/etl.py
@@ -102,19 +102,16 @@ def moose(
             )
 
         # run create variable
-
-        for variable_config in variable_configs:
-            for theta in thetas or [None]:
-                create_variable(
-                    config_path=variable_config,
-                    year=year,
-                    domain=domain,
-                    scale_factor=scale_factor,
-                    ensemble_member=ensemble_member,
-                    scenario=scenario,
-                    theta=theta,
-                    target_resolution=target_resolution,
-                )
+        create_variable(
+            config_paths=variable_configs,
+            year=year,
+            domain=domain,
+            scale_factor=scale_factor,
+            ensemble_member=ensemble_member,
+            scenario=scenario,
+            thetas=thetas,
+            target_resolution=target_resolution,
+        )
 
         # run clean up
         if cleanup:

--- a/src/mlde_data/bin/moose.py
+++ b/src/mlde_data/bin/moose.py
@@ -20,7 +20,7 @@ from ..moose import (
     load_cubes,
     MoosePPVariableMetadata,
 )
-from ..variables import SourceVariableConfig
+from ..variable import SourceVariableConfig
 
 iris.FUTURE.save_split_attrs = True
 

--- a/src/mlde_data/bin/variable.py
+++ b/src/mlde_data/bin/variable.py
@@ -1,5 +1,6 @@
 from codetiming import Timer
 from collections import defaultdict
+from dataclasses import dataclass
 import logging
 from mlde_utils import RAW_MOOSE_VARIABLES_PATH, DERIVED_VARIABLES_PATH
 from mlde_data.canari_le_sprint_variable_adapter import CanariLESprintVariableAdapter
@@ -34,43 +35,51 @@ def callback():
     pass
 
 
-def get_resolution(srcs_config: dict) -> str:
-    collection = CollectionOption(srcs_config["collection"])
-    if srcs_config["type"] == "moose":
+@dataclass(frozen=True)
+class SourceConfig:
+    type: str
+    collection: str
+    frequency: str
+    variable: str
+
+
+def get_resolution(src_config: SourceConfig) -> str:
+    collection = CollectionOption(src_config.collection)
+    if src_config.type == "moose":
         if collection == CollectionOption.cpm:
             resolution = "2.2km"
         elif collection == CollectionOption.gcm:
             resolution = "60km"
         else:
             raise f"Unknown collection {collection}"
-    elif srcs_config["type"] == "local":
+    elif src_config.type == "local":
         # assume local sourced data is pre-processed so resolution must be specified in config
-        resolution = srcs_config["resolution"]
-    elif srcs_config["type"] == "canari-le-sprint":
+        resolution = src_config.resolution
+    elif src_config.type == "canari-le-sprint":
         # CANARI LE Sprint data is at 60km resolution
         resolution = "60km"
 
     else:
-        raise RuntimeError(f"Unknown souce type {srcs_config['type']}")
+        raise RuntimeError(f"Unknown souce type {src_config.type}")
 
     return resolution
 
 
-def get_source_domain(srcs_config: dict) -> str:
-    collection = CollectionOption(srcs_config["collection"])
-    if srcs_config["type"] == "moose":
+def get_source_domain(src_config: SourceConfig) -> str:
+    collection = CollectionOption(src_config.collection)
+    if src_config.type == "moose":
         if collection == CollectionOption.cpm:
             domain = "uk"
         elif collection == CollectionOption.gcm:
             domain = "global"
         else:
             raise RuntimeError(f"Unknown collection {collection}")
-    elif srcs_config["type"] == "local":
-        domain = srcs_config["domain"]
-    elif srcs_config["type"] == "canari-le-sprint":
+    elif src_config.type == "local":
+        domain = src_config.domain
+    elif src_config.type == "canari-le-sprint":
         domain = "global"
     else:
-        raise RuntimeError(f"Unknown souce type {srcs_config['type']}")
+        raise RuntimeError(f"Unknown souce type {src_config.type}")
 
     return domain
 
@@ -116,26 +125,24 @@ def open_moose_source_variable(
     collection: str,
     base_dir: Path,
 ) -> xr.Dataset:
-    logger.info(f"Opening {src_variable['name']} moose extract...")
+    logger.info(f"Opening {src_variable} moose extract...")
     ds = open_pp_data(
         base_dir=base_dir / "pp",
         collection=CollectionOption(collection),
         scenario=scenario,
         ensemble_member=ensemble_member,
-        variable=src_variable["name"],
+        variable=src_variable,
         frequency=frequency,
         resolution=resolution,
         domain=domain,
         year=year,
     )
 
-    if "moose_name" in VARIABLE_CODES[src_variable["name"]]:
+    if "moose_name" in VARIABLE_CODES[src_variable]:
         logger.info(
-            f"Renaming {VARIABLE_CODES[src_variable['name']]['moose_name']} to {src_variable['name']}..."
+            f"Renaming {VARIABLE_CODES[src_variable]['moose_name']} to {src_variable['name']}..."
         )
-        ds = ds.rename(
-            {VARIABLE_CODES[src_variable["name"]]["moose_name"]: src_variable["name"]}
-        )
+        ds = ds.rename({VARIABLE_CODES[src_variable]["moose_name"]: src_variable})
     # remove forecast related coords that we don't need
     ds = remove_forecast(ds)
 
@@ -179,14 +186,15 @@ def combine_source_variables(sources: dict[str, xr.Dataset]) -> xr.Dataset:
 
 
 def open_source_variables(
-    srcs_config: dict,
+    src_configs: set[SourceConfig],
     year: int,
     ensemble_member: str,
     base_dir: Path,
 ) -> xr.Dataset:
     sources = {}
-    for src_variable in srcs_config["variables"]:
-        src_type = srcs_config["type"]
+    for src_config in src_configs:
+
+        src_type = src_config.type
 
         if src_type == "moose":
             source_open_strategy = open_moose_source_variable
@@ -197,14 +205,14 @@ def open_source_variables(
         else:
             raise RuntimeError(f"Unknown source type {src_type}")
 
-        collection = srcs_config["collection"]
-        resolution = get_resolution(srcs_config)
-        frequency = srcs_config["frequency"]
+        collection = src_config.collection
+        resolution = get_resolution(src_config)
+        frequency = src_config.frequency
         scenario = "rcp85"
-        domain = get_source_domain(srcs_config)
+        domain = get_source_domain(src_config)
 
-        sources[src_variable["name"]] = source_open_strategy(
-            src_variable,
+        sources[src_config.variable] = source_open_strategy(
+            src_config.variable,
             year,
             frequency,
             scenario,
@@ -215,7 +223,7 @@ def open_source_variables(
             base_dir,
         )
 
-    logger.info(f"Combining {srcs_config}...")
+    logger.info(f"Combining {src_configs}...")
     ds = combine_source_variables(sources).assign_attrs(
         {
             "domain": domain,
@@ -283,8 +291,8 @@ def _save(ds: xr.Dataset, config: dict, path: str, year: int) -> None:
 @app.command()
 @Timer(name="create-variable", text="{name}: {minutes:.1f} minutes", logger=logger.info)
 def create(
-    config_path: Path = typer.Option(...),
-    theta: int = None,
+    config_paths: list[Path] = typer.Option(...),
+    thetas: list[int] = None,
     scenario="rcp85",
     ensemble_member: str = typer.Option(...),
     year: int = typer.Option(...),
@@ -299,15 +307,32 @@ def create(
     Create a variable file in project form from source data
     """
 
-    config = load_config(
-        config_path,
-        scale_factor=scale_factor,
-        domain=domain.value,
-        theta=theta,
-        target_resolution=target_resolution,
-    )
+    configs = [
+        load_config(
+            config_path,
+            scale_factor=scale_factor,
+            domain=domain.value,
+            theta=theta,
+            target_resolution=target_resolution,
+        )
+        for config_path in config_paths
+        for theta in (thetas or [None])
+    ]
 
-    src_type = config["sources"]["type"]
+    src_configs = {
+        SourceConfig(
+            type=config["sources"]["type"],
+            collection=config["sources"]["collection"],
+            frequency=config["sources"]["frequency"],
+            variable=var_configs["name"],
+        )
+        for config in configs
+        for var_configs in config["sources"]["variables"]
+    }
+    src_type = {src_config.type for src_config in src_configs}
+    # TODO: support creating variables from multiple source types
+    assert len(src_type) == 1, "All variable configs must have the same source type"
+    src_type = src_type.pop()
 
     if input_base_dir is None:
         if src_type == "moose":
@@ -322,35 +347,36 @@ def create(
     if output_base_dir is None:
         output_base_dir = DERIVED_VARIABLES_PATH
 
-    ds = open_source_variables(
-        config["sources"],
+    src_ds = open_source_variables(
+        src_configs,
         year,
         ensemble_member,
         input_base_dir,
     )
+    for config in configs:
+        logger.info(f"Processing {config['variable']}...")
+        ds = _process(
+            src_ds,
+            config,
+        )
+        # # remove pressure related dims and encoding data that we don't need
+        # ds = remove_pressure(ds)
 
-    ds = _process(
-        ds,
-        config,
-    )
-    # # remove pressure related dims and encoding data that we don't need
-    # ds = remove_pressure(ds)
+        if validate:
+            _validate(ds, config)
 
-    if validate:
-        _validate(ds, config)
+        output_metadata = VariableMetadata(
+            output_base_dir,
+            frequency=ds.attrs["frequency"],
+            domain=ds.attrs["domain"],
+            resolution=ds.attrs["resolution"],
+            scenario=scenario,
+            ensemble_member=ensemble_member,
+            variable=config["variable"],
+            collection=config["sources"]["collection"],
+        )
 
-    output_metadata = VariableMetadata(
-        output_base_dir,
-        frequency=ds.attrs["frequency"],
-        domain=ds.attrs["domain"],
-        resolution=ds.attrs["resolution"],
-        scenario=scenario,
-        ensemble_member=ensemble_member,
-        variable=config["variable"],
-        collection=config["sources"]["collection"],
-    )
-
-    _save(ds, config, output_metadata.filepath(year), year)
+        _save(ds, config, output_metadata.filepath(year), year)
 
 
 @app.command()

--- a/src/mlde_data/bin/variable.py
+++ b/src/mlde_data/bin/variable.py
@@ -276,6 +276,13 @@ def create(
     assert len(src_type) == 1, "All variable configs must have the same source type"
     src_type = src_type.pop()
 
+    src_collection = {src_config.collection for src_config in src_configs}
+    # TODO: support creating variables from multiple source types
+    assert (
+        len(src_collection) == 1
+    ), "All variable configs must have the same source collection"
+    src_collection = src_collection.pop()
+
     if input_base_dir is None:
         if src_type == "moose":
             input_base_dir = RAW_MOOSE_VARIABLES_PATH
@@ -315,7 +322,7 @@ def create(
             scenario=scenario,
             ensemble_member=ensemble_member,
             variable=config["variable"],
-            collection=config["sources"]["collection"],
+            collection=src_collection,
         )
 
         _save(ds, config, output_metadata.filepath(year), year)

--- a/src/mlde_data/bin/variable.py
+++ b/src/mlde_data/bin/variable.py
@@ -102,7 +102,7 @@ def open_local_source_variable(
         scenario=scenario,
         domain=domain,
         ensemble_member=ensemble_member,
-        variable=src_variable["name"],
+        variable=src_variable,
         collection=collection,
     )
     source_nc_filepath = source_metadata.filepath(year)
@@ -140,7 +140,7 @@ def open_moose_source_variable(
 
     if "moose_name" in VARIABLE_CODES[src_variable]:
         logger.info(
-            f"Renaming {VARIABLE_CODES[src_variable]['moose_name']} to {src_variable['name']}..."
+            f"Renaming {VARIABLE_CODES[src_variable]['moose_name']} to {src_variable}..."
         )
         ds = ds.rename({VARIABLE_CODES[src_variable]["moose_name"]: src_variable})
     # remove forecast related coords that we don't need
@@ -163,7 +163,7 @@ def open_canari_le_sprint_source_variable(
     source_metadata = CanariLESprintVariableAdapter(
         frequency=frequency,
         ensemble_member=ensemble_member,
-        variable=src_variable["name"],
+        variable=src_variable,
         year=year,
     )
 

--- a/src/mlde_data/moose.py
+++ b/src/mlde_data/moose.py
@@ -395,7 +395,7 @@ def load_cubes(pp_files, variable, collection, realize=False):
 
 def open_pp_data(
     base_dir: Path,
-    collection: CollectionOption,
+    collection: str,
     scenario: str,
     ensemble_member: str,
     variable: str,
@@ -406,7 +406,7 @@ def open_pp_data(
 ) -> xr.Dataset:
     input_moose_pp_varmeta = MoosePPVariableMetadata(
         base_dir=base_dir,
-        collection=collection.value,
+        collection=collection,
         scenario=scenario,
         ensemble_member=ensemble_member,
         variable=variable,

--- a/src/mlde_data/variable/__init__.py
+++ b/src/mlde_data/variable/__init__.py
@@ -1,6 +1,50 @@
-from string import Template
+from dataclasses import dataclass
 from pathlib import Path
+from string import Template
 import yaml
+
+from mlde_data.options import CollectionOption
+
+
+@dataclass(frozen=True)
+class SourceVariableConfig:
+    src_type: str
+    collection: str
+    frequency: str
+    variable: str
+    resolution: str = None
+    domain: str = None
+
+    def __post_init__(self):
+        if self.src_type == "moose":
+            if self.collection == CollectionOption.cpm:
+                if self.resolution is None:
+                    self.resolution = "2.2km"
+                if self.domain is None:
+                    self.domain = "uk"
+            elif self.collection == CollectionOption.gcm:
+                if self.resolution is None:
+                    self.resolution = "60km"
+                if self.domain is None:
+                    self.domain = "global"
+            else:
+                raise f"Unknown collection {self.collection}"
+        elif self.src_type == "local":
+            # assume local sourced data is pre-processed so resolution and domain must be specified
+            assert (
+                self.resolution is not None
+            ), "resolution must be specified for local source variable"
+            assert (
+                self.domain is not None
+            ), "domain must be specified for local source variable"
+        elif self.src_type == "canari-le-sprint":
+            # assume CANARI LE Sprint data is at global 60km resolution
+            if self.resolution is None:
+                self.resolution = "60km"
+            if self.domain is None:
+                self.domain = "global"
+        else:
+            raise RuntimeError(f"Unknown souce type {self.src_type}")
 
 
 def load_config(
@@ -22,4 +66,15 @@ def load_config(
         src = Template(config_template.read())
         result = src.substitute(d)
         config = yaml.safe_load(result)
+
+    config["sources"] = {
+        SourceVariableConfig(
+            src_type=config["sources"]["type"],
+            collection=config["sources"]["collection"],
+            frequency=config["sources"]["frequency"],
+            variable=var_configs["name"],
+        )
+        for var_configs in config["sources"]["variables"]
+    }
+
     return config

--- a/src/mlde_data/variable/__init__.py
+++ b/src/mlde_data/variable/__init__.py
@@ -19,14 +19,14 @@ class SourceVariableConfig:
         if self.src_type == "moose":
             if self.collection == CollectionOption.cpm:
                 if self.resolution is None:
-                    self.resolution = "2.2km"
+                    object.__setattr__(self, "resolution", "2.2km")
                 if self.domain is None:
-                    self.domain = "uk"
+                    object.__setattr__(self, "domain", "uk")
             elif self.collection == CollectionOption.gcm:
                 if self.resolution is None:
-                    self.resolution = "60km"
+                    object.__setattr__(self, "resolution", "60km")
                 if self.domain is None:
-                    self.domain = "global"
+                    object.__setattr__(self, "domain", "global")
             else:
                 raise f"Unknown collection {self.collection}"
         elif self.src_type == "local":
@@ -40,9 +40,9 @@ class SourceVariableConfig:
         elif self.src_type == "canari-le-sprint":
             # assume CANARI LE Sprint data is at global 60km resolution
             if self.resolution is None:
-                self.resolution = "60km"
+                object.__setattr__(self, "resolution", "60km")
             if self.domain is None:
-                self.domain = "global"
+                object.__setattr__(self, "domain", "global")
         else:
             raise RuntimeError(f"Unknown souce type {self.src_type}")
 


### PR DESCRIPTION
Allow creation of multiple variables from the same extracted source variables without duplicating conversion from pp to xarray

Previously this was possible but each variable-create call would create a single variable and each time load the same pp data into xarray, which was slow. Now variable-create can create multiple variables in one call by merging their source variables (so just a single conversion from pp via iris to xarray).

Have also added a SourceVariableConfig object to handle this and overlap between the moose-etl pipeline command and variable-create command. However, lots of overlap with things like VariableMetadata and CanariLESprintVariableAdapter and MoosePPVariableMetadata that should be sorted.