### PR TITLE
Bug: time dimension unnecessarily on some variables and coords in datasets

### DIFF
--- a/src/mlde_data/dataset/__init__.py
+++ b/src/mlde_data/dataset/__init__.py
@@ -108,9 +108,8 @@ def create(config: dict, input_base_dir: Path) -> dict:
         )
 
         for split, split_times in split_sets.items():
-            split_ds = var_type_ds.where(
-                var_type_ds.time.dt.floor("1D").isin(split_times),
-                drop=True,
+            split_ds = var_type_ds.sel(
+                time=var_type_ds["time"].dt.floor("D").isin(split_times)
             )
             var_type_datasets[var_type][split] = split_ds
             var_type_statistics[var_type][split] = _calculate_statistics(

--- a/tests/bin/dataset/test_create.py
+++ b/tests/bin/dataset/test_create.py
@@ -66,7 +66,9 @@ def test_create(tmp_path, config_filepath, input_base_dir):
         for split in ["train", "val"]:
             data_filepath = expected_dsmeta.path() / split / f"{var_type}.zarr"
             assert_file(data_filepath)
-            xr.open_dataset(data_filepath)  # will raise error if file is invalid
+            ds = xr.open_dataset(data_filepath)  # will raise error if file is invalid
+            for k in ds.cf.grid_mapping_names.keys():
+                assert ds[k].dims == ()
 
             data_filepath = expected_dsmeta.path() / split / f"{var_type}_stats.zarr"
             assert_file(data_filepath)


### PR DESCRIPTION
Change how splits are selected from datasets to avoid adding unnecessary time dimensions to variables and coords that don't need them